### PR TITLE
이펙트 컴포넌트, Renderinfo 수정, title씬 수정 및 이펙트 추가

### DIFF
--- a/M_E/M_E/Renderer.h
+++ b/M_E/M_E/Renderer.h
@@ -12,7 +12,6 @@ struct renderInfo
     D2D1_RECT_F			srcRect{ 0.f, 0.f, 0.f, 0.f };
 
     float				opacity = 1.f;
-    int					zOrder = 0;
     bool				activated = true;
 };
 

--- a/Sinclair/Sinclair/BackgroundComponent.cpp
+++ b/Sinclair/Sinclair/BackgroundComponent.cpp
@@ -4,8 +4,6 @@
 
 void BackgroundComponent::Update()
 {
-    if (m_currentName == "Background")   return;
-    SetCurrentBitmap("Background");
 }
 
 void BackgroundComponent::BitmapPush(string NM, ComPtr<ID2D1Bitmap1> Bitmap)

--- a/Sinclair/Sinclair/EffectComponent.cpp
+++ b/Sinclair/Sinclair/EffectComponent.cpp
@@ -2,27 +2,19 @@
 
 GaussianBlur_Effect::GaussianBlur_Effect(RenderInfo* renderInfo, float strength, ID2D1Bitmap1* bitmap) : m_renderInfo(renderInfo), m_strength(strength), m_bitmap(bitmap)
 {
-	HRESULT hr = D2DRenderer::Get().GetD2DContext()->CreateEffect(CLSID_D2D1GaussianBlur, &m_gaussianBlurEffect);
-	DX::ThrowIfFailed(hr);
-}
-
-GaussianBlur_Effect::GaussianBlur_Effect(RenderInfo* renderInfo, float strength, const wchar_t* path) : m_renderInfo(renderInfo), m_strength(strength)
-{
-	HRESULT hr = D2DRenderer::Get().GetD2DContext()->CreateEffect(CLSID_D2D1GaussianBlur, &m_gaussianBlurEffect);
-	DX::ThrowIfFailed(hr);
-
-	D2DRenderer::Get().CreateBitmapFromFile(path, m_bitmap.GetAddressOf());
-	if (m_bitmap == nullptr)	std::cout << "GaussianBlur_Effect : 비트맵 생성 실패\n";
+	Initialize();
 }
 
 GaussianBlur_Effect::GaussianBlur_Effect(RenderInfo* renderInfo, float strength, ID2D1Effect* pEffect) : m_renderInfo(renderInfo), m_strength(strength), m_effect(pEffect)
 {
-	HRESULT hr = D2DRenderer::Get().GetD2DContext()->CreateEffect(CLSID_D2D1GaussianBlur, &m_gaussianBlurEffect);
-	DX::ThrowIfFailed(hr);
+	Initialize();
 }
 
-void GaussianBlur_Effect::Update()
+void GaussianBlur_Effect::Initialize()
 {
+	HRESULT hr = D2DRenderer::Get().GetD2DContext()->CreateEffect(CLSID_D2D1GaussianBlur, &m_gaussianBlurEffect);
+	DX::ThrowIfFailed(hr);
+
 	if (m_effect == nullptr)
 		m_gaussianBlurEffect->SetInput(0, m_bitmap.Get());
 	else
@@ -33,88 +25,98 @@ void GaussianBlur_Effect::Update()
 	m_renderInfo->SetEffect(m_gaussianBlurEffect.Get());
 }
 
+void GaussianBlur_Effect::Update()
+{
+
+}
+
 Shadow_Effect::Shadow_Effect(RenderInfo* renderInfo, float edgeBlur, float r, float g, float b, float a, ID2D1Bitmap1* bitmap)
 	: m_renderInfo(renderInfo), m_edgeBlur(edgeBlur), m_shadowColor{ r, g, b, a }, m_bitmap(bitmap)
 {
-	HRESULT hr = D2DRenderer::Get().GetD2DContext()->CreateEffect(CLSID_D2D1Shadow, &m_shadowEffect);
-	DX::ThrowIfFailed(hr);
-}
-
-Shadow_Effect::Shadow_Effect(RenderInfo* renderInfo, float edgeBlur, float r, float g, float b, float a,  const wchar_t* path)
-	: m_renderInfo(renderInfo), m_edgeBlur(edgeBlur), m_shadowColor{ r, g, b, a }
-{
-	HRESULT hr = D2DRenderer::Get().GetD2DContext()->CreateEffect(CLSID_D2D1Shadow, &m_shadowEffect);
-	DX::ThrowIfFailed(hr);
-
-	D2DRenderer::Get().CreateBitmapFromFile(path, m_bitmap.GetAddressOf());
-	if (m_bitmap == nullptr)	std::cout << "Shadow_Effect : 비트맵 생성 실패\n";
+	Initialize();
 }
 
 Shadow_Effect::Shadow_Effect(RenderInfo* renderInfo, float edgeBlur, float r, float g, float b, float a, ID2D1Effect* effect)
 	: m_renderInfo(renderInfo), m_edgeBlur(edgeBlur), m_shadowColor{ r, g, b, a }, m_effect(effect)
 {
-	HRESULT hr = D2DRenderer::Get().GetD2DContext()->CreateEffect(CLSID_D2D1Shadow, &m_shadowEffect);
-	DX::ThrowIfFailed(hr);
+	Initialize();
 }
 
-void Shadow_Effect::Update()
+void Shadow_Effect::Initialize()
 {
+	HRESULT hr = D2DRenderer::Get().GetD2DContext()->CreateEffect(CLSID_D2D1Shadow, &m_shadowEffect);
+	DX::ThrowIfFailed(hr);
+
 	if (m_effect == nullptr)
 		m_shadowEffect->SetInput(0, m_bitmap.Get());
 	else
 		m_shadowEffect->SetInputEffect(0, m_effect);
+
 	m_shadowEffect->SetValue(D2D1_SHADOW_PROP_BLUR_STANDARD_DEVIATION, m_edgeBlur);
 	m_shadowEffect->SetValue(D2D1_SHADOW_PROP_COLOR, m_shadowColor);
 
 	m_renderInfo->SetEffect(m_shadowEffect.Get());
 }
 
+void Shadow_Effect::Update()
+{
+}
+
 Composite_Effect::Composite_Effect(RenderInfo* renderInfo, ID2D1Effect* top, ID2D1Effect* bottom, D2D1_COMPOSITE_MODE mode)
 	: m_renderInfo(renderInfo), m_EffectT(top), m_EffectB(bottom), m_mode(mode)
 {
-	HRESULT hr = D2DRenderer::Get().GetD2DContext()->CreateEffect(CLSID_D2D1Composite, &m_compositeEffect);
-	DX::ThrowIfFailed(hr);
+	Initialize();
 }
 
 Composite_Effect::Composite_Effect(RenderInfo* renderInfo, ID2D1Bitmap1* top, ID2D1Effect* bottom, D2D1_COMPOSITE_MODE mode)
 	: m_renderInfo(renderInfo), m_bitmapT(top), m_EffectB(bottom), m_mode(mode)
 {
-	HRESULT hr = D2DRenderer::Get().GetD2DContext()->CreateEffect(CLSID_D2D1Composite, &m_compositeEffect);
-	DX::ThrowIfFailed(hr);
+	Initialize();
 }
 
 Composite_Effect::Composite_Effect(RenderInfo* renderInfo, ID2D1Effect* top, ID2D1Bitmap1* bottom, D2D1_COMPOSITE_MODE mode)
 	: m_renderInfo(renderInfo), m_EffectT(top), m_bitmapB(bottom), m_mode(mode)
 {
-	HRESULT hr = D2DRenderer::Get().GetD2DContext()->CreateEffect(CLSID_D2D1Composite, &m_compositeEffect);
-	DX::ThrowIfFailed(hr);
-}
-
-Composite_Effect::Composite_Effect(RenderInfo* renderInfo, const wchar_t* top, ID2D1Bitmap1* bottom, D2D1_COMPOSITE_MODE mode)
-	: m_renderInfo(renderInfo), m_bitmapB(bottom), m_mode(mode)
-{
-	HRESULT hr = D2DRenderer::Get().GetD2DContext()->CreateEffect(CLSID_D2D1Composite, &m_compositeEffect);
-	DX::ThrowIfFailed(hr);
-
-	D2DRenderer::Get().CreateBitmapFromFile(top, m_bitmapT.GetAddressOf());
-	if (m_bitmapT == nullptr)	std::cout << "Composite_Effect : 비트맵 생성 실패\n";
-}
-
-Composite_Effect::Composite_Effect(RenderInfo* renderInfo, ID2D1Bitmap1* top, const wchar_t* bottom, D2D1_COMPOSITE_MODE mode)
-	: m_renderInfo(renderInfo), m_bitmapT(top), m_mode(mode)
-{
-	HRESULT hr = D2DRenderer::Get().GetD2DContext()->CreateEffect(CLSID_D2D1Composite, &m_compositeEffect);
-	DX::ThrowIfFailed(hr);
-
-	D2DRenderer::Get().CreateBitmapFromFile(bottom, m_bitmapB.GetAddressOf());
-	if (m_bitmapB == nullptr)	std::cout << "Composite_Effect : 비트맵 생성 실패\n";
+	Initialize();
 }
 
 Composite_Effect::Composite_Effect(RenderInfo* renderInfo, ID2D1Bitmap1* top, ID2D1Bitmap1* bottom, D2D1_COMPOSITE_MODE mode)
 	: m_renderInfo(renderInfo), m_bitmapT(top), m_bitmapB(bottom), m_mode(mode)
 {
+	Initialize();
+}
+
+void Composite_Effect::Initialize()
+{
 	HRESULT hr = D2DRenderer::Get().GetD2DContext()->CreateEffect(CLSID_D2D1Composite, &m_compositeEffect);
 	DX::ThrowIfFailed(hr);
+
+	if (m_EffectT != nullptr && m_EffectB != nullptr)
+	{
+		m_compositeEffect->SetInputEffect(0, m_EffectB);
+		m_compositeEffect->SetInputEffect(1, m_EffectT);
+		m_compositeEffect->SetValue(D2D1_COMPOSITE_PROP_MODE, m_mode);
+	}
+	else if (m_bitmapT != nullptr && m_EffectB != nullptr)
+	{
+		m_compositeEffect->SetInputEffect(0, m_EffectB);
+		m_compositeEffect->SetInput(1, m_bitmapT.Get());
+		m_compositeEffect->SetValue(D2D1_COMPOSITE_PROP_MODE, m_mode);
+	}
+	else if (m_EffectT != nullptr && m_bitmapB != nullptr)
+	{
+		m_compositeEffect->SetInput(0, m_bitmapB.Get());
+		m_compositeEffect->SetInputEffect(1, m_EffectT);
+		m_compositeEffect->SetValue(D2D1_COMPOSITE_PROP_MODE, m_mode);
+	}
+	else if (m_bitmapT != nullptr && m_bitmapB != nullptr)
+	{
+		m_compositeEffect->SetInput(0, m_bitmapB.Get());
+		m_compositeEffect->SetInput(1, m_bitmapT.Get());
+		m_compositeEffect->SetValue(D2D1_COMPOSITE_PROP_MODE, m_mode);
+	}
+
+	m_renderInfo->SetEffect(m_compositeEffect.Get());
 }
 
 void Composite_Effect::Update()
@@ -150,101 +152,99 @@ void Composite_Effect::Update()
 Crop_Effect::Crop_Effect(RenderInfo* renderInfo, float x, float y, float width, float height, ID2D1Effect* effect)
 	: m_renderInfo(renderInfo), m_rect{ x, y, width, height }, m_effect(effect)
 {
-	HRESULT hr = D2DRenderer::Get().GetD2DContext()->CreateEffect(CLSID_D2D1Crop, &m_cropEffect);
-	DX::ThrowIfFailed(hr);
+	Initialize();
 }
 
 Crop_Effect::Crop_Effect(RenderInfo* renderInfo, float x, float y, float width, float height, ID2D1Bitmap1* bitmap)
 	: m_renderInfo(renderInfo), m_rect{ x, y, width, height }, m_bitmap(bitmap)
 {
-	HRESULT hr = D2DRenderer::Get().GetD2DContext()->CreateEffect(CLSID_D2D1Crop, &m_cropEffect);
-	DX::ThrowIfFailed(hr);
+	Initialize();
 }
 
-Crop_Effect::Crop_Effect(RenderInfo* renderInfo, float x, float y, float width, float height, const wchar_t* path)
-	: m_renderInfo(renderInfo), m_rect{ x, y, width, height }
+Crop_Effect::Crop_Effect(RenderInfo* renderInfo, D2D1_RECT_F srcRect, ID2D1Effect* effect)
+	: m_renderInfo(renderInfo), m_rect(srcRect), m_effect(effect)
+{
+	Initialize();
+}
+
+Crop_Effect::Crop_Effect(RenderInfo* renderInfo, D2D1_RECT_F srcRect, ID2D1Bitmap1* bitmap)
+	: m_renderInfo(renderInfo), m_rect(srcRect), m_bitmap(bitmap)
+{
+	Initialize();
+}
+
+void Crop_Effect::Initialize()
 {
 	HRESULT hr = D2DRenderer::Get().GetD2DContext()->CreateEffect(CLSID_D2D1Crop, &m_cropEffect);
 	DX::ThrowIfFailed(hr);
 
-	D2DRenderer::Get().CreateBitmapFromFile(path, m_bitmap.GetAddressOf());
-	if (m_bitmap == nullptr)	std::cout << "Crop_Effect : 비트맵 생성 실패\n";
-}
-
-void Crop_Effect::Update()
-{
 	if (m_effect == nullptr)
 		m_cropEffect->SetInput(0, m_bitmap.Get());
 	else
 		m_cropEffect->SetInputEffect(0, m_effect);
+
 	m_cropEffect->SetValue(D2D1_CROP_PROP_RECT, m_rect);
 
 	m_renderInfo->SetEffect(m_cropEffect.Get());
 }
 
+void Crop_Effect::Update()
+{
+
+}
+
 Contrast_Effect::Contrast_Effect(RenderInfo* renderInfo, float strength, ID2D1Effect* effect) : m_renderInfo(renderInfo), m_strength(strength), m_effect(effect)
 {
-	HRESULT hr = D2DRenderer::Get().GetD2DContext()->CreateEffect(CLSID_D2D1Contrast, &m_contrastEffect);
-	DX::ThrowIfFailed(hr);
+	Initialize();
 }
 
 Contrast_Effect::Contrast_Effect(RenderInfo* renderInfo, float strength, ID2D1Bitmap1* bitmap) : m_renderInfo(renderInfo), m_strength(strength), m_bitmap(bitmap)
 {
-	HRESULT hr = D2DRenderer::Get().GetD2DContext()->CreateEffect(CLSID_D2D1Contrast, &m_contrastEffect);
-	DX::ThrowIfFailed(hr);
+	Initialize();
 }
 
-Contrast_Effect::Contrast_Effect(RenderInfo* renderInfo, float strength, const wchar_t* path) : m_renderInfo(renderInfo), m_strength(strength)
+void Contrast_Effect::Initialize()
 {
 	HRESULT hr = D2DRenderer::Get().GetD2DContext()->CreateEffect(CLSID_D2D1Contrast, &m_contrastEffect);
 	DX::ThrowIfFailed(hr);
 
-	D2DRenderer::Get().CreateBitmapFromFile(path, m_bitmap.GetAddressOf());
-	if (m_bitmap == nullptr)	std::cout << "Contrast_Effect : 비트맵 생성 실패\n";
-}
-
-void Contrast_Effect::Update()
-{
 	if (m_effect == nullptr)
 		m_contrastEffect->SetInput(0, m_bitmap.Get());
 	else
 		m_contrastEffect->SetInputEffect(0, m_effect);
+
 	m_contrastEffect->SetValue(D2D1_CONTRAST_PROP_CONTRAST, m_strength);
 	m_contrastEffect->SetValue(D2D1_CONTRAST_PROP_CLAMP_INPUT, true);
 
 	m_renderInfo->SetEffect(m_contrastEffect.Get());
 }
 
+void Contrast_Effect::Update()
+{
+}
+
 Vignette_Effect::Vignette_Effect(RenderInfo* renderInfo, float blurRadius, float strength, float r, float g, float b, float a, ID2D1Effect* effect)
 	: m_renderInfo(renderInfo), m_blurRadius(blurRadius), m_strength(strength), m_color{ r, g, b, a }, m_effect(effect)
 {
-	HRESULT hr = D2DRenderer::Get().GetD2DContext()->CreateEffect(CLSID_D2D1Vignette, &m_vignetteEffect);
-	DX::ThrowIfFailed(hr);
+	Initialize();
 }
 
 Vignette_Effect::Vignette_Effect(RenderInfo* renderInfo, float blurRadius, float strength, float r, float g, float b, float a, ID2D1Bitmap1* bitmap)
 	: m_renderInfo(renderInfo), m_blurRadius(blurRadius), m_strength(strength), m_color{ r, g, b, a }, m_bitmap(bitmap)
 {
-	HRESULT hr = D2DRenderer::Get().GetD2DContext()->CreateEffect(CLSID_D2D1Vignette, &m_vignetteEffect);
-	DX::ThrowIfFailed(hr);
+	Initialize();
 }
 
-Vignette_Effect::Vignette_Effect(RenderInfo* renderInfo, float blurRadius, float strength, float r, float g, float b, float a, const wchar_t* path)
-	: m_renderInfo(renderInfo), m_blurRadius(blurRadius), m_strength(strength), m_color{ r, g, b, a }
+void Vignette_Effect::Initialize()
 {
 	HRESULT hr = D2DRenderer::Get().GetD2DContext()->CreateEffect(CLSID_D2D1Vignette, &m_vignetteEffect);
 	DX::ThrowIfFailed(hr);
 
-	D2DRenderer::Get().CreateBitmapFromFile(path, m_bitmap.GetAddressOf());
-	if (m_bitmap == nullptr)	std::cout << "Vignette_Effect : 비트맵 생성 실패\n";
-}
-
-void Vignette_Effect::Update()
-{
 	if (m_effect == nullptr)
 		m_vignetteEffect->SetInput(0, m_bitmap.Get());
 	else
 		m_vignetteEffect->SetInputEffect(0, m_effect);
+
 	m_vignetteEffect->SetValue(D2D1_VIGNETTE_PROP_COLOR, m_color);
 	m_vignetteEffect->SetValue(D2D1_VIGNETTE_PROP_TRANSITION_SIZE, m_blurRadius);
 	m_vignetteEffect->SetValue(D2D1_VIGNETTE_PROP_STRENGTH, m_strength);
@@ -252,68 +252,59 @@ void Vignette_Effect::Update()
 	m_renderInfo->SetEffect(m_vignetteEffect.Get());
 }
 
+void Vignette_Effect::Update()
+{
+}
+
 Scale_Effect::Scale_Effect(RenderInfo* renderInfo, float pivotX, float pivotY, float scaleX, float scaleY, ID2D1Effect* effect)
 	: m_renderInfo(renderInfo), m_pivot{ pivotX, pivotY }, m_scale{ scaleX, scaleY }, m_effect(effect)
 {
-	HRESULT hr = D2DRenderer::Get().GetD2DContext()->CreateEffect(CLSID_D2D1Scale, &m_scaleEffect);
-	DX::ThrowIfFailed(hr);
+	Initialize();
 }
 
 Scale_Effect::Scale_Effect(RenderInfo* renderInfo, float pivotX, float pivotY, float scaleX, float scaleY, ID2D1Bitmap1* bitmap)
 	: m_renderInfo(renderInfo), m_pivot{ pivotX, pivotY }, m_scale{ scaleX, scaleY }, m_bitmap(bitmap)
 {
-	HRESULT hr = D2DRenderer::Get().GetD2DContext()->CreateEffect(CLSID_D2D1Scale, &m_scaleEffect);
-	DX::ThrowIfFailed(hr);
+	Initialize();
 }
 
-Scale_Effect::Scale_Effect(RenderInfo* renderInfo, float pivotX, float pivotY, float scaleX, float scaleY, const wchar_t* path)
-	: m_renderInfo(renderInfo), m_pivot{ pivotX, pivotY }, m_scale{ scaleX, scaleY }
+void Scale_Effect::Initialize()
 {
 	HRESULT hr = D2DRenderer::Get().GetD2DContext()->CreateEffect(CLSID_D2D1Scale, &m_scaleEffect);
 	DX::ThrowIfFailed(hr);
 
-	D2DRenderer::Get().CreateBitmapFromFile(path, m_bitmap.GetAddressOf());
-	if (m_bitmap == nullptr)	std::cout << "Scale_Effect : 비트맵 생성 실패\n";
-}
-
-void Scale_Effect::Update()
-{
 	if (m_effect == nullptr)
 		m_scaleEffect->SetInput(0, m_bitmap.Get());
 	else
 		m_scaleEffect->SetInputEffect(0, m_effect);
+
 	m_scaleEffect->SetValue(D2D1_SCALE_PROP_CENTER_POINT, m_pivot);
 	m_scaleEffect->SetValue(D2D1_SCALE_PROP_SCALE, m_scale);
 
 	m_renderInfo->SetEffect(m_scaleEffect.Get());
 }
 
+void Scale_Effect::Update()
+{
+}
+
 Posterize_Effect::Posterize_Effect(RenderInfo* renderInfo, int redStep, int greenStep, int blueStep, ID2D1Effect* effect)
 	: m_renderInfo(renderInfo), m_redStep(redStep), m_greenStep(greenStep), m_blueStep(blueStep), m_effect(effect)
 {
-	HRESULT hr = D2DRenderer::Get().GetD2DContext()->CreateEffect(CLSID_D2D1Posterize, &m_posterEffect);
-	DX::ThrowIfFailed(hr);
+	Initialize();
 }
 
 Posterize_Effect::Posterize_Effect(RenderInfo* renderInfo, int redStep, int greenStep, int blueStep, ID2D1Bitmap1* bitmap)
 	: m_renderInfo(renderInfo), m_redStep(redStep), m_greenStep(greenStep), m_blueStep(blueStep), m_bitmap(bitmap)
 {
-	HRESULT hr = D2DRenderer::Get().GetD2DContext()->CreateEffect(CLSID_D2D1Posterize, &m_posterEffect);
-	DX::ThrowIfFailed(hr);
+	Initialize();
 }
 
-Posterize_Effect::Posterize_Effect(RenderInfo* renderInfo, int redStep, int greenStep, int blueStep, const wchar_t* path)
-	: m_renderInfo(renderInfo), m_redStep(redStep), m_greenStep(greenStep), m_blueStep(blueStep)
+void Posterize_Effect::Initialize()
 {
 	HRESULT hr = D2DRenderer::Get().GetD2DContext()->CreateEffect(CLSID_D2D1Posterize, &m_posterEffect);
 	DX::ThrowIfFailed(hr);
 
-	D2DRenderer::Get().CreateBitmapFromFile(path, m_bitmap.GetAddressOf());
-	if (m_bitmap == nullptr)	std::cout << "Posterize_Effect : 비트맵 생성 실패\n";
-}
-
-void Posterize_Effect::Update()
-{
 	if (m_effect == nullptr)
 		m_posterEffect->SetInput(0, m_bitmap.Get());
 	else
@@ -325,32 +316,27 @@ void Posterize_Effect::Update()
 	m_renderInfo->SetEffect(m_posterEffect.Get());
 }
 
+void Posterize_Effect::Update()
+{
+}
+
 Gray_Effect::Gray_Effect(RenderInfo* renderInfo, float strength, ID2D1Effect* effect)
 	: m_renderInfo(renderInfo), m_strength(strength), m_effect(effect)
 {
-	HRESULT hr = D2DRenderer::Get().GetD2DContext()->CreateEffect(CLSID_D2D1Saturation, &m_grayEffect);
-	DX::ThrowIfFailed(hr);
+	Initialize();
 }
 
 Gray_Effect::Gray_Effect(RenderInfo* renderInfo, float strength, ID2D1Bitmap1* bitmap)
 	: m_renderInfo(renderInfo), m_strength(strength), m_bitmap(bitmap)
 {
-	HRESULT hr = D2DRenderer::Get().GetD2DContext()->CreateEffect(CLSID_D2D1Saturation, &m_grayEffect);
-	DX::ThrowIfFailed(hr);
+	Initialize();
 }
 
-Gray_Effect::Gray_Effect(RenderInfo* renderInfo, float strength, const wchar_t* path)
-	: m_renderInfo(renderInfo), m_strength(strength)
+void Gray_Effect::Initialize()
 {
 	HRESULT hr = D2DRenderer::Get().GetD2DContext()->CreateEffect(CLSID_D2D1Saturation, &m_grayEffect);
 	DX::ThrowIfFailed(hr);
 
-	D2DRenderer::Get().CreateBitmapFromFile(path, m_bitmap.GetAddressOf());
-	if (m_bitmap == nullptr)	std::cout << "Gray_Effect : 비트맵 생성 실패\n";
-}
-
-void Gray_Effect::Update()
-{
 	if (m_effect == nullptr)
 		m_grayEffect->SetInput(0, m_bitmap.Get());
 	else
@@ -360,32 +346,28 @@ void Gray_Effect::Update()
 	m_renderInfo->SetEffect(m_grayEffect.Get());
 }
 
+void Gray_Effect::Update()
+{
+
+}
+
 Rotate3D_Effect::Rotate3D_Effect(RenderInfo* renderInfo, float depth, float pivotX, float pivotY, float rotateX, float rotateY, float rotateZ, ID2D1Effect* effect)
 	: m_renderInfo(renderInfo), m_depth(depth), m_pivot{ pivotX, pivotY, 0.f }, m_rotate{ rotateX, rotateY, rotateZ }, m_effect(effect)
 {
-	HRESULT hr = D2DRenderer::Get().GetD2DContext()->CreateEffect(CLSID_D2D13DPerspectiveTransform, &m_perspectiveEffect);
-	DX::ThrowIfFailed(hr);
+	Initialize();
 }
 
 Rotate3D_Effect::Rotate3D_Effect(RenderInfo* renderInfo, float depth, float pivotX, float pivotY, float rotateX, float rotateY, float rotateZ, ID2D1Bitmap1* bitmap)
 	: m_renderInfo(renderInfo), m_depth(depth), m_pivot{ pivotX, pivotY, 0.f }, m_rotate{ rotateX, rotateY, rotateZ }, m_bitmap(bitmap)
 {
-	HRESULT hr = D2DRenderer::Get().GetD2DContext()->CreateEffect(CLSID_D2D13DPerspectiveTransform, &m_perspectiveEffect);
-	DX::ThrowIfFailed(hr);
+	Initialize();
 }
 
-Rotate3D_Effect::Rotate3D_Effect(RenderInfo* renderInfo, float depth, float pivotX, float pivotY, float rotateX, float rotateY, float rotateZ, const wchar_t* path)
-	: m_renderInfo(renderInfo), m_depth(depth), m_pivot{ pivotX, pivotY, 0.f }, m_rotate { rotateX, rotateY, rotateZ }
+void Rotate3D_Effect::Initialize()
 {
 	HRESULT hr = D2DRenderer::Get().GetD2DContext()->CreateEffect(CLSID_D2D13DPerspectiveTransform, &m_perspectiveEffect);
 	DX::ThrowIfFailed(hr);
 
-	D2DRenderer::Get().CreateBitmapFromFile(path, m_bitmap.GetAddressOf());
-	if (m_bitmap == nullptr)	std::cout << "Rotate3D_Effect : 비트맵 생성 실패\n";
-}
-
-void Rotate3D_Effect::Update()
-{
 	if (m_effect == nullptr)
 	{
 		m_perspectiveEffect->SetInput(0, m_bitmap.Get());
@@ -394,7 +376,7 @@ void Rotate3D_Effect::Update()
 	{
 		m_perspectiveEffect->SetInputEffect(0, m_effect);
 	}
-	
+
 	m_perspectiveEffect->SetValue(D2D1_3DPERSPECTIVETRANSFORM_PROP_ROTATION_ORIGIN, m_pivot);
 
 	m_rotation.x = fmod((m_rotation.x + m_rotate.x), 360.f);	m_rotation.y = fmod((m_rotation.y + m_rotate.y), 360.f);	m_rotation.z = fmod((m_rotation.z + m_rotate.z), 360.f);
@@ -406,36 +388,35 @@ void Rotate3D_Effect::Update()
 	m_renderInfo->SetEffect(m_perspectiveEffect.Get());
 }
 
+void Rotate3D_Effect::Update()
+{
+	m_rotation.x = fmod((m_rotation.x + m_rotate.x), 360.f);	m_rotation.y = fmod((m_rotation.y + m_rotate.y), 360.f);	m_rotation.z = fmod((m_rotation.z + m_rotate.z), 360.f);
+	m_perspectiveEffect->SetValue(D2D1_3DPERSPECTIVETRANSFORM_PROP_ROTATION, m_rotation);
+	m_renderInfo->SetEffect(m_perspectiveEffect.Get());
+}
+
 Offset_Effect::Offset_Effect(RenderInfo* renderInfo, float xOffset, float yOffset, ID2D1Bitmap1* bitmap)
 	: m_renderInfo(renderInfo), m_xOffset(xOffset), m_yOffset(yOffset), m_bitmap(bitmap)
 {
-	HRESULT hr = D2DRenderer::Get().GetD2DContext()->CreateEffect(CLSID_D2D12DAffineTransform, &m_offsetEffect);
-	DX::ThrowIfFailed(hr);
-}
-
-Offset_Effect::Offset_Effect(RenderInfo* renderInfo, float xOffset, float yOffset, const wchar_t* path)
-	: m_renderInfo(renderInfo), m_xOffset(xOffset), m_yOffset(yOffset)
-{
-	HRESULT hr = D2DRenderer::Get().GetD2DContext()->CreateEffect(CLSID_D2D12DAffineTransform, &m_offsetEffect);
-	DX::ThrowIfFailed(hr);
-
-	D2DRenderer::Get().CreateBitmapFromFile(path, m_bitmap.GetAddressOf());
-	if (m_bitmap == nullptr)	std::cout << "Offset_Effect : 비트맵 생성 실패\n";
+	Initialize();
 }
 
 Offset_Effect::Offset_Effect(RenderInfo* renderInfo, float xOffset, float yOffset, ID2D1Effect* effect)
 	: m_renderInfo(renderInfo), m_xOffset(xOffset), m_yOffset(yOffset), m_effect(effect)
 {
-	HRESULT hr = D2DRenderer::Get().GetD2DContext()->CreateEffect(CLSID_D2D12DAffineTransform, &m_offsetEffect);
-	DX::ThrowIfFailed(hr);
+	Initialize();
 }
 
-void Offset_Effect::Update()
+void Offset_Effect::Initialize()
 {
+	HRESULT hr = D2DRenderer::Get().GetD2DContext()->CreateEffect(CLSID_D2D12DAffineTransform, &m_offsetEffect);
+	DX::ThrowIfFailed(hr);
+
 	if (m_effect == nullptr)
 		m_offsetEffect->SetInput(0, m_bitmap.Get());
 	else
 		m_offsetEffect->SetInputEffect(0, m_effect);
+
 	D2D1_MATRIX_3X2_F offsetMT = D2D1::Matrix3x2F::Translation(m_xOffset, m_yOffset);
 	m_offsetEffect->SetValue(D2D1_2DAFFINETRANSFORM_PROP_TRANSFORM_MATRIX, offsetMT);
 	m_offsetEffect->SetValue(D2D1_2DAFFINETRANSFORM_PROP_INTERPOLATION_MODE, D2D1_2DAFFINETRANSFORM_INTERPOLATION_MODE_LINEAR);
@@ -443,116 +424,74 @@ void Offset_Effect::Update()
 	m_renderInfo->SetEffect(m_offsetEffect.Get());
 }
 
-//Particle_Effect::Particle_Effect(int particle_count)
-//{
-//	m_Particles.reserve(1000); // 초기 파티클 개수 예약
-//
-//	for (int i = 0; i < count; i++)
-//	{
-//		Particle p;
-//		p.size = D2D1::SizeF(100.f, 100.f);
-//	
-//		float x = safeMargin + static_cast<float>(rand() % static_cast<int>(screenWidth - p.size.width - safeMargin));
-//		float y = safeMargin + static_cast<float>(rand() % static_cast<int>(screenHeight - p.size.height - safeMargin));
-//
-//		p.position = D2D1::Point2F(x + p.size.width / 2.f, y + p.size.height / 2.f);	// 중심좌표
-//
-//		p.rotation = static_cast<float>(rand() % 360);
-//		p.age = 0.0f;
-//		p.lifetime = 1.5f + static_cast<float>(rand() % 100) / 5.f;
-//
-//		//int frameIndex = rand() % 4;
-//		//p.sourceRect = GetFrameRect(frameIndex);
-//		p.sourceRect.left = 0.f;
-//		p.sourceRect.top = 0.f;
-//		p.sourceRect.right = 420.f;
-//		p.sourceRect.bottom = 420.f;
-//
-//		p.color = D2D1::ColorF(1.0f, 1.0f, 1.0f, 1.0f);
-//
-//		m_Particles.push_back(p);
-//	}
-//}
-//
-//void Particle_Effect::Update()
-//{
-//}
-//
-//void Particle_Effect::FixedUpdate(float dt)
-//{
-//	if (isStop) return;
-//
-//	static float time = 0;
-//	static float x = 0;
-//
-//	time += dt;
-//	if (time >= FPS60)
-//	{
-//		if (time >= 5.f)	time = 0.f;		// 처음 dt가 5이상 큰 수가 들어옴
-//		else
-//		{
-//			time -= FPS60;
-//			x += FPS60;
-//		}
-//	}
-//
-//	for (auto& p : m_Particles)
-//	{
-//		p.age += x;
-//
-//		// 간단한 연출: 위로 천천히 이동 (불꽃 상승)
-//		p.position.y -= x * 30.f;
-//
-//		// 점점 사라지기 (fade-out)
-//		float t = p.age / p.lifetime;
-//		t = std::clamp(t, 0.f, 1.f);
-//		p.color.a = 1.f - t;
-//	}
-//
-//	m_Particles.erase(
-//		std::remove_if(m_Particles.begin(), m_Particles.end(),
-//			[](const Particle& p) {return p.age >= p.lifetime; }),
-//		m_Particles.end()
-//	);
-//}
+void Offset_Effect::Update()
+{
+
+}
 
 Color_Effect::Color_Effect(RenderInfo* renderInfo, float r, float g, float b, float a, ID2D1Effect* effect)
 	: m_renderInfo(renderInfo), m_r(r), m_g(g), m_b(b), m_a(a), m_effect(effect)
 {
-	HRESULT hr = D2DRenderer::Get().GetD2DContext()->CreateEffect(CLSID_D2D1ColorMatrix, &m_colorEffect);
-	DX::ThrowIfFailed(hr);
+	Initialize();
 }
 
 Color_Effect::Color_Effect(RenderInfo* renderInfo, float r, float g, float b, float a, ID2D1Bitmap1* bitmap)
 	: m_renderInfo(renderInfo), m_r(r), m_g(g), m_b(b), m_a(a), m_bitmap(bitmap)
 {
-	HRESULT hr = D2DRenderer::Get().GetD2DContext()->CreateEffect(CLSID_D2D1ColorMatrix, &m_colorEffect);
-	DX::ThrowIfFailed(hr);
+	Initialize();
 }
 
-Color_Effect::Color_Effect(RenderInfo* renderInfo, float r, float g, float b, float a, const wchar_t* path)
-	: m_renderInfo(renderInfo), m_r(r), m_g(g), m_b(b), m_a(a)
+void Color_Effect::Initialize()
 {
 	HRESULT hr = D2DRenderer::Get().GetD2DContext()->CreateEffect(CLSID_D2D1ColorMatrix, &m_colorEffect);
 	DX::ThrowIfFailed(hr);
 
-	D2DRenderer::Get().CreateBitmapFromFile(path, m_bitmap.GetAddressOf());
-	if (m_bitmap == nullptr)	std::cout << "Offset_Effect : 비트맵 생성 실패\n";
-}
-
-void Color_Effect::Update()
-{
 	if (m_effect == nullptr)
 		m_colorEffect->SetInput(0, m_bitmap.Get());
 	else
 		m_colorEffect->SetInputEffect(0, m_effect);
+
 	D2D1_MATRIX_5X4_F matrix = D2D1::Matrix5x4F
-	(	m_r, 0, 0, 0,
+	(m_r, 0, 0, 0,
 		0, m_g, 0, 0,
 		0, 0, m_b, 0,
 		0, 0, 0, m_a,
-		0, 0, 0, 0	);
+		0, 0, 0, 0);
 	m_colorEffect->SetValue(D2D1_COLORMATRIX_PROP_COLOR_MATRIX, matrix);
 
 	m_renderInfo->SetEffect(m_colorEffect.Get());
+}
+
+void Color_Effect::Update()
+{
+
+}
+
+Border_Effect::Border_Effect(RenderInfo* renderInfo, ID2D1Effect* effect)
+	: m_renderInfo(renderInfo), m_effect(effect)
+{
+	Initialize();
+}
+
+Border_Effect::Border_Effect(RenderInfo* renderInfo, ID2D1Bitmap1* bitmap)
+	:m_renderInfo(renderInfo), m_bitmap(bitmap)
+{
+	Initialize();
+}
+
+void Border_Effect::Initialize()
+{
+	HRESULT hr = D2DRenderer::Get().GetD2DContext()->CreateEffect(CLSID_D2D1Border, &m_borderEffect);
+	DX::ThrowIfFailed(hr);
+
+	if (m_effect == nullptr)
+		m_borderEffect->SetInput(0, m_bitmap.Get());
+	else
+		m_borderEffect->SetInputEffect(0, m_effect);
+	m_borderEffect->SetValue(D2D1_BORDER_PROP_EDGE_MODE_X, D2D1_BORDER_EDGE_MODE_CLAMP);
+	m_borderEffect->SetValue(D2D1_BORDER_PROP_EDGE_MODE_Y, D2D1_BORDER_EDGE_MODE_CLAMP);
+}
+
+void Border_Effect::Update()
+{
 }

--- a/Sinclair/Sinclair/EffectComponent.h
+++ b/Sinclair/Sinclair/EffectComponent.h
@@ -11,7 +11,7 @@ using namespace Microsoft::WRL;
 class GaussianBlur_Effect;					// 블러 효과
 class Shadow_Effect;						// 그림자 효과
 class Offset_Effect;						// 이동 효과
-//class Composite_Effect;						// 이미지 합성 효과
+class Composite_Effect;						// 이미지 합성 효과
 class Crop_Effect;							// 이미지 크롭 효과
 class Contrast_Effect;						// 이미지 대비 강조 효과
 class Vignette_Effect;						// 테두리 음영 적용 효과
@@ -20,14 +20,16 @@ class Posterize_Effect;						// 포스터화 효과 : 만화같은 느낌이나 복고풍 느낌을 
 class Gray_Effect;							// 무채색화 효과
 class Rotate3D_Effect;						// 3D 회전 효과
 class Color_Effect;							// 색상 바꾸기 효과
+class Border_Effect;						// 이미지가 해상도를 벗어낫을 때 설정 효과
 
 class GaussianBlur_Effect : public Component				// 블러 효과
 {
 public:
 	GaussianBlur_Effect(RenderInfo* renderInfo, float strength, ID2D1Bitmap1* bitmap);	// 오브젝트의 비트맵에 효과 적용
-	GaussianBlur_Effect(RenderInfo* renderInfo, float strength, const wchar_t* path);	// 다른 비트맵 생성하여 효과 적용
 	GaussianBlur_Effect(RenderInfo* renderInfo, float strength, ID2D1Effect* pEffect);	// 다른 이펙트가 적용된 비트맵에 효과 적용
 	~GaussianBlur_Effect() { m_gaussianBlurEffect.Reset(); }
+
+	void Initialize();
 
 	void Update() override;
 
@@ -49,8 +51,9 @@ class Shadow_Effect : public Component			// 그림자 효과
 {
 public:
 	Shadow_Effect(RenderInfo* renderInfo, float edgeBlur, float r, float g, float b, float a, ID2D1Bitmap1* bitmap);	// 오브젝트의 비트맵에 효과 적용
-	Shadow_Effect(RenderInfo* renderInfo, float edgeBlur, float r, float g, float b, float a, const wchar_t* path);		// 다른 비트맵 생성하여 효과 적용
 	Shadow_Effect(RenderInfo* renderInfo, float edgeBlur, float r, float g, float b, float a, ID2D1Effect* effect);		// 다른 이펙트가 적용된 비트맵에 효과 적용
+
+	void Initialize();
 
 	~Shadow_Effect() { m_shadowEffect.Reset(); }
 
@@ -77,9 +80,10 @@ class Offset_Effect : public Component
 {
 public:
 	Offset_Effect(RenderInfo* renderInfo, float xOffset, float yOffset, ID2D1Bitmap1* bitmap);
-	Offset_Effect(RenderInfo* renderInfo, float xOffset, float yOffset, const wchar_t* path);
 	Offset_Effect(RenderInfo* renderInfo, float xOffset, float yOffset, ID2D1Effect* effect);
 	~Offset_Effect() { m_offsetEffect.Reset(); }
+
+	void Initialize();
 
 	void Update() override;
 
@@ -104,10 +108,10 @@ public:
 	Composite_Effect(RenderInfo* renderInfo, ID2D1Effect* top, ID2D1Effect* bottom, D2D1_COMPOSITE_MODE mode);		// 이펙트끼리 합성
 	Composite_Effect(RenderInfo* renderInfo, ID2D1Bitmap1* top, ID2D1Effect* bottom, D2D1_COMPOSITE_MODE mode);		// 비트맵(위)과 이펙트(아래) 합성
 	Composite_Effect(RenderInfo* renderInfo, ID2D1Effect* top, ID2D1Bitmap1* bottom, D2D1_COMPOSITE_MODE mode);		// 비트맵(아래)과 이펙트(위) 합성
-	Composite_Effect(RenderInfo* renderInfo, const wchar_t* top, ID2D1Bitmap1* bottom, D2D1_COMPOSITE_MODE mode);	// 새 이미지(위)와 비트맵(아래) 합성
-	Composite_Effect(RenderInfo* renderInfo, ID2D1Bitmap1* top, const wchar_t* bottom, D2D1_COMPOSITE_MODE mode);	// 새 이미지(아래)와 비트맵(위) 합성
 	Composite_Effect(RenderInfo* renderInfo, ID2D1Bitmap1* top, ID2D1Bitmap1* bottom, D2D1_COMPOSITE_MODE mode);
 	~Composite_Effect() { m_compositeEffect.Reset(); }
+
+	void Initialize();
 
 	void Update() override;
 
@@ -132,8 +136,11 @@ class Crop_Effect : public Component		// 이미지 크롭 효과
 public:
 	Crop_Effect(RenderInfo* renderInfo, float x, float y, float width, float height, ID2D1Effect* effect);
 	Crop_Effect(RenderInfo* renderInfo, float x, float y, float width, float height, ID2D1Bitmap1* bitmap);
-	Crop_Effect(RenderInfo* renderInfo, float x, float y, float width, float height, const wchar_t* path);
+	Crop_Effect(RenderInfo* renderInfo, D2D1_RECT_F srcRect, ID2D1Effect* effect);
+	Crop_Effect(RenderInfo* renderInfo, D2D1_RECT_F srcRect, ID2D1Bitmap1* bitmap);
 	~Crop_Effect() { m_cropEffect.Reset(); }
+
+	void Initialize();
 
 	void Update() override;
 
@@ -161,8 +168,9 @@ class Contrast_Effect : public Component		// 이미지 대비 강조 효과
 public:
 	Contrast_Effect(RenderInfo* renderInfo, float strength, ID2D1Effect* effect);
 	Contrast_Effect(RenderInfo* renderInfo, float strength, ID2D1Bitmap1* bitmap);
-	Contrast_Effect(RenderInfo* renderInfo, float strength, const wchar_t* path);
 	~Contrast_Effect() { m_contrastEffect.Reset(); }
+
+	void Initialize();
 
 	void Update() override;
 
@@ -186,8 +194,9 @@ class Vignette_Effect : public Component	// 테두리 음영 적용 효과
 public:
 	Vignette_Effect(RenderInfo* renderInfo, float blurRadius, float strength, float r, float g, float b, float a, ID2D1Effect* effect);
 	Vignette_Effect(RenderInfo* renderInfo, float blurRadius, float strength, float r, float g, float b, float a, ID2D1Bitmap1* bitmap);
-	Vignette_Effect(RenderInfo* renderInfo, float blurRadius, float strength, float r, float g, float b, float a, const wchar_t* path);
 	~Vignette_Effect() { m_vignetteEffect.Reset(); }
+
+	void Initialize();
 
 	void Update() override;
 
@@ -215,8 +224,9 @@ class Scale_Effect : public Component		// 스케일 조정 효과
 public:
 	Scale_Effect(RenderInfo* renderInfo, float pivotX, float pivotY, float scaleX, float scaleY, ID2D1Effect* effect);
 	Scale_Effect(RenderInfo* renderInfo, float pivotX, float pivotY, float scaleX, float scaleY, ID2D1Bitmap1* bitmap);
-	Scale_Effect(RenderInfo* renderInfo, float pivotX, float pivotY, float scaleX, float scaleY, const wchar_t* path);
 	~Scale_Effect() { m_scaleEffect.Reset(); }
+
+	void Initialize();
 
 	void Update() override;
 
@@ -243,8 +253,9 @@ class Posterize_Effect : public Component
 public:
 	Posterize_Effect(RenderInfo* renderInfo, int redStep, int greenStep, int blueStep, ID2D1Effect* effect);
 	Posterize_Effect(RenderInfo* renderInfo, int redStep, int greenStep, int blueStep, ID2D1Bitmap1* bitmap);
-	Posterize_Effect(RenderInfo* renderInfo, int redStep, int greenStep, int blueStep, const wchar_t* path);
 	~Posterize_Effect() { m_posterEffect.Reset(); }
+
+	void Initialize();
 
 	void Update() override;
 
@@ -273,8 +284,9 @@ class Gray_Effect : public Component	// 그레이화 효과
 public:
 	Gray_Effect(RenderInfo* renderInfo, float strength, ID2D1Effect* effect);
 	Gray_Effect(RenderInfo* renderInfo, float strength, ID2D1Bitmap1* bitmap);
-	Gray_Effect(RenderInfo* renderInfo, float strength, const wchar_t* path);
 	~Gray_Effect() { m_grayEffect.Reset(); }
+
+	void Initialize();
 
 	void Update() override;
 
@@ -295,10 +307,11 @@ private:
 class Rotate3D_Effect : public Component	// 회전 효과
 {
 public:
-	Rotate3D_Effect(RenderInfo* renderInfo, float depth, float pivotX, float pivotY,  float rotateX, float rotateY, float rotateZ, ID2D1Effect* effect);
-	Rotate3D_Effect(RenderInfo* renderInfo, float depth, float pivotX, float pivotY,  float rotateX, float rotateY, float rotateZ, ID2D1Bitmap1* bitmap);
-	Rotate3D_Effect(RenderInfo* renderInfo, float depth, float pivotX, float pivotY,  float rotateX, float rotateY, float rotateZ, const wchar_t* path);
+	Rotate3D_Effect(RenderInfo* renderInfo, float depth, float pivotX, float pivotY, float rotateX, float rotateY, float rotateZ, ID2D1Effect* effect);
+	Rotate3D_Effect(RenderInfo* renderInfo, float depth, float pivotX, float pivotY, float rotateX, float rotateY, float rotateZ, ID2D1Bitmap1* bitmap);
 	~Rotate3D_Effect() { m_perspectiveEffect.Reset(); }
+
+	void Initialize();
 
 	void Update() override;
 
@@ -325,7 +338,9 @@ class Color_Effect : public Component
 public:
 	Color_Effect(RenderInfo* renderInfo, float r, float g, float b, float a, ID2D1Effect* effect);
 	Color_Effect(RenderInfo* renderInfo, float r, float g, float b, float a, ID2D1Bitmap1* bitmap);
-	Color_Effect(RenderInfo* renderInfo, float r, float g, float b, float a, const wchar_t* path);
+	~Color_Effect() { m_colorEffect.Reset(); }
+
+	void Initialize();
 
 	void Update() override;
 
@@ -344,34 +359,24 @@ private:
 	RenderInfo* m_renderInfo = nullptr;
 };
 
-//struct Particle
-//{
-//	D2D1_POINT_2F position;
-//	D2D1_SIZE_F size;
-//
-//	D2D1_RECT_U sourceRect;     // 시트 내 프레임
-//	D2D1_COLOR_F color;         // Tint + alpha
-//
-//	float rotation;             // 도 단위 (degrees)
-//	float age;                  // 생존 시간
-//	float lifetime;
-//};
-//
-//class Particle_Effect : public Component
-//{
-//public:
-//	Particle_Effect(int particle_count);
-//
-//	void Update() override;
-//	void FixedUpdate(float dt) override;
-//
-//private:
-//	int count = 100;
-//	float safeMargin = 10.f;
-//	float screenWidth = 1920.f;
-//	float screenHeight = 1080.f;
-//
-//	bool isStop = false;
-//
-//	std::vector<Particle> m_Particles;
-//};
+class Border_Effect : public Component
+{
+public:
+	Border_Effect(RenderInfo* renderInfo, ID2D1Effect* effect);
+	Border_Effect(RenderInfo* renderInfo, ID2D1Bitmap1* bitmap);
+	~Border_Effect() { m_borderEffect.Reset(); }
+
+	void Initialize();
+
+	void Update() override;
+
+	ID2D1Effect* GetEffect() { return m_borderEffect.Get(); }
+private:
+
+	ID2D1Effect* m_effect = nullptr;
+	ComPtr<ID2D1Bitmap1> m_bitmap = nullptr;
+
+	ComPtr<ID2D1Effect> m_borderEffect;
+
+	RenderInfo* m_renderInfo = nullptr;
+};

--- a/Sinclair/Sinclair/PlayComponent.cpp
+++ b/Sinclair/Sinclair/PlayComponent.cpp
@@ -1,5 +1,38 @@
 #include "PlayComponent.h"
 
+Slide_Effect::Slide_Effect(RenderInfo* renderInfo, Transform& transform, float speed, float bitmapWidth, float screenWidth, bool isRight)
+	: m_renderInfo(renderInfo), m_transform(transform), m_speed(speed), m_bitmapWidth(bitmapWidth), m_screenWidth(screenWidth), m_isRight(isRight)
+{
+}
+
+void Slide_Effect::Update()
+{
+	if (isStop)	return;
+
+	if (m_isRight)
+	{
+		m_transform.Translate(-m_speed, 0.f);
+		if (-m_bitmapWidth >= m_transform.GetPosition().x)	m_transform.SetPosition({ m_screenWidth, m_transform.GetPosition().y });
+	}
+	else if (!m_isRight)
+	{
+		m_transform.Translate(m_speed, 0.f);
+		if (m_screenWidth <= m_transform.GetPosition().x)	m_transform.SetPosition({ -m_bitmapWidth, m_transform.GetPosition().y });
+	}
+}
+
+void Slide_Effect::OnEvent(const std::string& ev)
+{
+	if (ev == "STOP")
+	{
+		isStop = true;
+	}
+	else if (ev == "PLAY")
+	{
+		isStop = false;
+	}
+}
+
 UpDown_Effect::UpDown_Effect(RenderInfo* renderInfo, Transform& transform, float moveAmount, float upSpeed, float downSpeed)
 	: m_renderInfo(renderInfo), m_transform(transform), m_moveAmount(moveAmount), m_upSpeed(upSpeed), m_downSpeed(downSpeed)
 {
@@ -34,45 +67,32 @@ void UpDown_Effect::OnEvent(const std::string& ev)
 	}
 }
 
-//Rotate_Effect::Rotate_Effect(RenderInfo* renderInfo, Transform& transform, float rotate)
-//	: m_renderInfo(renderInfo), m_transform(transform), m_rotate(rotate)
-//{
-//	/*transform.SetPivotPreset(PivotPreset::Center, m_renderInfo->GetSize());*/
-//}
-//
-//void Rotate_Effect::Update()
-//{
-//	if (isStop)	return;
-//
-//	m_transform.Rotate(m_rotate);
-//
-//	m_renderInfo->SetWorldTM(m_transform.GetWorldMatrix());
-//	std::cout << m_transform.GetPivotPoint().x << std::endl;
-//}
-//
-//void Rotate_Effect::OnEvent(const std::string& ev)
-//{
-//	if (ev == "STOP")
-//	{
-//		isStop = true;
-//	}
-//	else if (ev == "PLAY")
-//	{
-//		isStop = false;
-//	}
-//}
-
-Explode_Effect::Explode_Effect(RenderInfo* renderInfo, Transform& transform, float x_maxScale, float y_maxScale, float totalSecond)
-	: m_renderInfo(renderInfo), m_transform(transform), mx_maxScale(x_maxScale), my_maxScale(y_maxScale), m_totalSecond(totalSecond)
+Blink_Effect::Blink_Effect(RenderInfo* renderInfo, float minOpacity, float totalSecond, ID2D1Effect* effect)
+	: m_renderInfo(renderInfo), m_minOpacity(minOpacity), m_totalSecond(totalSecond), m_effect(effect)
 {
-	m_scale = m_transform.GetScale();
+	Initialize();
 }
 
-void Explode_Effect::FixedUpdate(float dt)
+Blink_Effect::Blink_Effect(RenderInfo* renderInfo, float minOpacity, float totalSecond, ID2D1Bitmap1* bitmap)
+	: m_renderInfo(renderInfo), m_minOpacity(minOpacity), m_totalSecond(totalSecond), m_bitmap(bitmap)
 {
-	if (isStop)	return;
-	static float time = 0;
-	static float x = 0;
+	Initialize();
+}
+
+void Blink_Effect::Initialize()
+{
+	HRESULT hr = D2DRenderer::Get().GetD2DContext()->CreateEffect(CLSID_D2D1Opacity, &m_opacityEffect);
+	DX::ThrowIfFailed(hr);
+
+	if (m_effect == nullptr)
+		m_opacityEffect->SetInput(0, m_bitmap.Get());
+	else
+		m_opacityEffect->SetInputEffect(0, m_effect);
+}
+
+void Blink_Effect::FixedUpdate(float dt)
+{
+	if (isStop) return;
 
 	time += dt;
 	if (time >= FPS60)
@@ -85,17 +105,69 @@ void Explode_Effect::FixedUpdate(float dt)
 		}
 	}
 
-	D2D1_VECTOR_2F scale{ m_scale.x + Graph(x, mx_maxScale), m_scale.y + Graph(x, my_maxScale) };
-	m_transform.SetScale(scale);
-
-	if (m_transform.GetScale().x < 0.f && m_transform.GetScale().y < 0.f)
+	if (x >= m_totalSecond)
 	{
 		x = 0.f;
-		m_renderInfo->SetisActive(false);
-		m_transform.SetScale(m_scale);
+	}
 
+	m_opacityEffect->SetValue(D2D1_COMPOSITE_MODE_SOURCE_OVER, Graph(x));
+}
+
+Explode_Effect::Explode_Effect(RenderInfo* renderInfo, float x_currentScale, float y_currentScale, float x_addScale, float y_addScale, float totalSecond, ID2D1Effect* effect)
+	: m_renderInfo(renderInfo), m_currentScale{ x_currentScale, y_currentScale }, mx_addScale(x_addScale), my_addScale(y_addScale), m_totalSecond(totalSecond), m_effect(effect)
+{
+	Initialize();
+}
+
+Explode_Effect::Explode_Effect(RenderInfo* renderInfo, float x_currentScale, float y_currentScale, float x_addScale, float y_addScale, float totalSecond, ID2D1Bitmap1* bitmap)
+	: m_renderInfo(renderInfo), m_currentScale{ x_currentScale, y_currentScale }, mx_addScale(x_addScale), my_addScale(y_addScale), m_totalSecond(totalSecond), m_bitmap(bitmap)
+{
+	Initialize();
+}
+
+void Explode_Effect::Initialize()
+{
+	HRESULT hr = D2DRenderer::Get().GetD2DContext()->CreateEffect(CLSID_D2D12DAffineTransform, &m_offsetEffect);
+	DX::ThrowIfFailed(hr);
+
+	if (m_effect == nullptr)
+		m_offsetEffect->SetInput(0, m_bitmap.Get());
+	else
+		m_offsetEffect->SetInputEffect(0, m_effect);
+
+	m_offsetEffect->SetValue(D2D1_2DAFFINETRANSFORM_PROP_INTERPOLATION_MODE, D2D1_2DAFFINETRANSFORM_INTERPOLATION_MODE_LINEAR);
+}
+
+void Explode_Effect::FixedUpdate(float dt)
+{
+	if (isStop)	return;
+
+	time += dt;
+	if (time >= FPS60)
+	{
+		if (time >= 5.f)	time = 0.f;		// 처음 dt가 5이상 큰 수가 들어옴
+		else
+		{
+			time -= FPS60;
+			x += FPS60;
+		}
+	}
+
+	D2D1_VECTOR_2F scale;
+
+	scale = { Graph(x, mx_addScale), Graph(x, my_addScale) };
+
+	D2D1_MATRIX_3X2_F offsetMT = D2D1::Matrix3x2F::Scale(scale.x, scale.y, { m_renderInfo->GetSize().width / 2.f, m_renderInfo->GetSize().height / 2.f });
+	m_offsetEffect->SetValue(D2D1_2DAFFINETRANSFORM_PROP_TRANSFORM_MATRIX, offsetMT);
+
+	if (scale.x < 0.f && scale.y < 0.f)
+	{
+		x = 0;
+		m_renderInfo->SetisActive(false);
+		//isFirst = false;
 		isStop = true;
 	}
+	m_renderInfo->SetEffect(m_offsetEffect.Get());
 }
 
 void Explode_Effect::OnEvent(const std::string& ev)
@@ -104,81 +176,7 @@ void Explode_Effect::OnEvent(const std::string& ev)
 	{
 		isStop = false;
 		m_renderInfo->SetisActive(true);
-	}
-}
-
-Blinking_Effect::Blinking_Effect(RenderInfo* renderInfo, float minOpacity, float totalSecond)
-	: m_renderInfo(renderInfo), m_minOpacity(minOpacity), m_totalSecond(totalSecond)
-{
-	//std::cout << m_totalSecond << std::endl;
-}
-
-void Blinking_Effect::FixedUpdate(float dt)
-{
-	if (isStop) return;
-
-	static float time = 0;
-	static float x = 0;
-
-	time += dt;
-	if (time >= FPS60)
-	{
-		if (time >= 100.f)	time = 0.f;		// 처음 dt가 5이상 큰 수가 들어옴
-		else
-		{
-			time -= FPS60;
-			x += FPS60;
-		}
-	}
-
-	m_renderInfo->SetOpacity(Graph(x));
-	if (x >= m_totalSecond)
-	{
-		x = 0.f;
-	}
-}
-
-void Blinking_Effect::OnEvent(const std::string& ev)
-{
-	if (ev == "STOP")
-	{
-		isStop = true;
-	}
-	else if (ev == "PLAY")
-	{
-		isStop = false;
-	}
-}
-
-Slide_Effect::Slide_Effect(RenderInfo* renderInfo, Transform& transform, float speed, float bitmapWidth, float screenWidth, bool isRight)
-	: m_renderInfo(renderInfo), m_transform(transform), m_speed(speed), m_bitmapWidth(bitmapWidth), m_screenWidth(screenWidth), m_isRight(isRight)
-{
-}
-
-void Slide_Effect::Update()
-{
-	if (isStop)	return;
-
-	if (m_isRight)
-	{
-		m_transform.Translate(-m_speed, 0.f);
-		if (-m_bitmapWidth >= m_transform.GetPosition().x)	m_transform.SetPosition({ m_screenWidth, m_transform.GetPosition().y });
-	}
-	else if (!m_isRight)
-	{
-		m_transform.Translate(m_speed, 0.f);
-		if (m_screenWidth <= m_transform.GetPosition().x)	m_transform.SetPosition({ -m_bitmapWidth, m_transform.GetPosition().y });
-	}
-}
-
-void Slide_Effect::OnEvent(const std::string& ev)
-{
-	if (ev == "STOP")
-	{
-		isStop = true;
-	}
-	else if (ev == "PLAY")
-	{
-		isStop = false;
+		//D2D1_MATRIX_3X2_F offsetMT = D2D1::Matrix3x2F::Scale(m_currentScale.x, m_currentScale.y, { m_renderInfo->GetSize().width / 2.f, m_renderInfo->GetSize().height / 2.f });
+		//m_offsetEffect->SetValue(D2D1_2DAFFINETRANSFORM_PROP_TRANSFORM_MATRIX, offsetMT);
 	}
 }

--- a/Sinclair/Sinclair/RenderInfo.h
+++ b/Sinclair/Sinclair/RenderInfo.h
@@ -11,6 +11,17 @@ public:
 
 	RenderInfo(ID2D1Bitmap1* bitmap) { SetBitmap(bitmap); }
 
+	void Clear()
+	{
+		m_renderInfo.bitmap = nullptr;
+		m_renderInfo.effect = nullptr;
+		m_renderInfo.mt = D2D1::Matrix3x2F::Identity();
+		m_renderInfo.destRect.left = m_renderInfo.destRect.top = m_renderInfo.destRect.right = m_renderInfo.destRect.bottom = 0.f;
+		m_renderInfo.srcRect.left = m_renderInfo.srcRect.top = m_renderInfo.srcRect.right = m_renderInfo.srcRect.bottom = 0.f;
+		m_renderInfo.opacity = 1.f;
+		m_renderInfo.activated = true;
+	}
+
 	void SetBitmap(ID2D1Bitmap1* bitmap)		// 비트맵 변경 시, src에 비트맵 사이즈 들어감. dest는 따로 설정 필요.
 	{
 		m_renderInfo.bitmap = bitmap;
@@ -47,11 +58,6 @@ public:
 		m_renderInfo.opacity = opacity;
 	}
 
-	void SetzOrder(int zOrder)
-	{
-		m_renderInfo.zOrder = zOrder;
-	}
-
 	void SetisActive(bool activated)
 	{
 		m_renderInfo.activated = activated;
@@ -60,12 +66,7 @@ public:
 	const D2D1_SIZE_F GetSize()			// src rect의 너비와 높이
 	{ 
 		return { m_renderInfo.srcRect.right - m_renderInfo.srcRect.left, m_renderInfo.srcRect.bottom - m_renderInfo.srcRect.top }; 
-	}
-
-	//renderInfo& GetReference()								// obj 내 다른 component에서 사용
-	//{ 
-	//	return m_renderInfo; 
-	//}		
+	}	
 														
 	const renderInfo& GetRenderInfo()							// Scene - Render()에서 사용
 	{ 

--- a/Sinclair/Sinclair/Scene_MK.cpp
+++ b/Sinclair/Sinclair/Scene_MK.cpp
@@ -29,70 +29,70 @@ void Scene_MK::Initalize()
 	//////////////////////
 	// Background 
 
-	// 1. 이미지 갖고 오기
-	auto gameStartBackground = ResourceManager::Get().GetTexture("시작화면");
-	// 2. 오브젝트 만들기
-	auto Background = std::make_unique<Object>();
-	Background->SetPosition(Vec2(0, 0));
-	// 3. 컴포넌트 넣기
-	auto renderinfo = Background->GetRenderInfo();
-	renderinfo->SetBitmap(gameStartBackground.Get());
-	auto bgComp = Background->AddComponent<BackgroundComponent>(renderinfo);
-	// 3.1.1 사이즈 다르면 
-	bgComp->SetWidth(1920); bgComp->SetHeight(1080);
-	bgComp->BitmapPush("Background", gameStartBackground);
-	
-	// 9. 게임 오브젝트들에 집어넣기
-	m_gameObjects.emplace("1Background", std::move(Background));
+	//// 1. 이미지 갖고 오기
+	//auto gameStartBackground = ResourceManager::Get().GetTexture("시작화면");
+	//// 2. 오브젝트 만들기
+	//auto Background = std::make_unique<Object>();
+	//Background->SetPosition(Vec2(0, 0));
+	//// 3. 컴포넌트 넣기
+	//auto renderinfo = Background->GetRenderInfo();
+	//renderinfo->SetBitmap(gameStartBackground.Get());
+	//auto bgComp = Background->AddComponent<BackgroundComponent>(renderinfo);
+	//// 3.1.1 사이즈 다르면 
+	//bgComp->SetWidth(1920); bgComp->SetHeight(1080);
+	//bgComp->BitmapPush("Background", gameStartBackground);
+	//
+	//// 9. 게임 오브젝트들에 집어넣기
+	//m_gameObjects.emplace("1Background", std::move(Background));
 
 
-	auto dustBitmap = ResourceManager::Get().GetTexture("airParticle");
+	//auto dustBitmap = ResourceManager::Get().GetTexture("airParticle");
 
-	auto Dust1 = std::make_unique<Object>();
-	auto dustInfo1 = Dust1->GetRenderInfo();
-	dustInfo1->SetBitmap(dustBitmap.Get());
-	auto blur1 = Dust1->AddComponent<GaussianBlur_Effect>(dustInfo1, 3.f, dustBitmap.Get());
-	auto updown = Dust1->AddComponent<UpDown_Effect>(dustInfo1, Dust1->GetTransform(), 5.f, 0.02f, 0.02f);
-	auto slide = Dust1->AddComponent<Slide_Effect>(dustInfo1, Dust1->GetTransform(), 0.05f, dustBitmap.Get()->GetSize().width, 1920.f, true);
-	m_gameObjects.emplace("2Dust", std::move(Dust1));
+	//auto Dust1 = std::make_unique<Object>();
+	//auto dustInfo1 = Dust1->GetRenderInfo();
+	//dustInfo1->SetBitmap(dustBitmap.Get());
+	//auto blur1 = Dust1->AddComponent<GaussianBlur_Effect>(dustInfo1, 3.f, dustBitmap.Get());
+	//auto updown = Dust1->AddComponent<UpDown_Effect>(dustInfo1, Dust1->GetTransform(), 5.f, 0.02f, 0.02f);
+	//auto slide = Dust1->AddComponent<Slide_Effect>(dustInfo1, Dust1->GetTransform(), 0.05f, dustBitmap.Get()->GetSize().width, 1920.f, true);
+	//m_gameObjects.emplace("2Dust", std::move(Dust1));
 
-	auto Dust2 = std::make_unique<Object>();
-	auto dustInfo2 = Dust2->GetRenderInfo();
-	dustInfo2->SetBitmap(dustBitmap.Get());	// SetBitmap을 해줘야 srcRect 비트맵 크기로 초기화됨
+	//auto Dust2 = std::make_unique<Object>();
+	//auto dustInfo2 = Dust2->GetRenderInfo();
+	//dustInfo2->SetBitmap(dustBitmap.Get());	// SetBitmap을 해줘야 srcRect 비트맵 크기로 초기화됨
 
-	Dust2->GetTransform().SetPosition({ 1920.f, 0.f });
-	auto blur11 = Dust2->AddComponent<GaussianBlur_Effect>(dustInfo2, 3.f, dustBitmap.Get());
-	auto updownn = Dust2->AddComponent<UpDown_Effect>(dustInfo2, Dust2->GetTransform(), 5.f, 0.02f, 0.02f);
-	auto slidee = Dust2->AddComponent<Slide_Effect>(dustInfo2, Dust2->GetTransform(), 0.05f, dustBitmap.Get()->GetSize().width, 1920.f, true);
+	//Dust2->GetTransform().SetPosition({ 1920.f, 0.f });
+	//auto blur11 = Dust2->AddComponent<GaussianBlur_Effect>(dustInfo2, 3.f, dustBitmap.Get());
+	//auto updownn = Dust2->AddComponent<UpDown_Effect>(dustInfo2, Dust2->GetTransform(), 5.f, 0.02f, 0.02f);
+	//auto slidee = Dust2->AddComponent<Slide_Effect>(dustInfo2, Dust2->GetTransform(), 0.05f, dustBitmap.Get()->GetSize().width, 1920.f, true);
 
-	m_gameObjects.emplace("3Dust", std::move(Dust2));
+	//m_gameObjects.emplace("3Dust", std::move(Dust2));
 
-	auto rayBitmap = ResourceManager::Get().GetTexture("portalRays");
-	auto ray = std::make_unique<Object>();
-	auto rayInfo = ray->GetRenderInfo();
-	rayInfo->SetBitmap(rayBitmap.Get());
-	ray->GetTransform().SetPosition({ 200.f, 200.f });
-	ray->GetTransform().SetPivotPreset(PivotPreset::Center, { rayBitmap.Get()->GetSize().width, rayBitmap.Get()->GetSize().height });
-	auto blink = ray->AddComponent<Blinking_Effect>(rayInfo, 0.85f, 5.f);
-	auto perspect = ray->AddComponent<Rotate3D_Effect>(rayInfo, 0.f, rayBitmap.Get()->GetSize().width / 2.f, rayBitmap.Get()->GetSize().height / 2.f, 0.f, 0.f, 0.2f, rayBitmap.Get());
-	auto perspect2 = ray->AddComponent<Rotate3D_Effect>(rayInfo, 0.f, rayBitmap.Get()->GetSize().width / 2.f, rayBitmap.Get()->GetSize().height / 2.f, 0.f, 0.f, -0.2f, rayBitmap.Get());
-	auto composite = ray->AddComponent<Composite_Effect>(rayInfo, perspect->GetEffect(), perspect2->GetEffect(), D2D1_COMPOSITE_MODE_SOURCE_OVER);
-	//auto colorRay = ray->AddComponent<Color_Effect>(rayInfo, 255.f / 256.f, 192.f / 256.f, 203.f / 256.f, 1.f, composite->GetEffect());
-	//auto explodeRay = ray->AddComponent<Explode_Effect>(rayInfo, ray->GetTransform(), 3.f, 3.f, 0.5f);
+	//auto rayBitmap = ResourceManager::Get().GetTexture("portalRays");
+	//auto ray = std::make_unique<Object>();
+	//auto rayInfo = ray->GetRenderInfo();
+	//rayInfo->SetBitmap(rayBitmap.Get());
+	//ray->GetTransform().SetPosition({ 200.f, 200.f });
+	//ray->GetTransform().SetPivotPreset(PivotPreset::Center, { rayBitmap.Get()->GetSize().width, rayBitmap.Get()->GetSize().height });
+	//auto blink = ray->AddComponent<Blinking_Effect>(rayInfo, 0.85f, 5.f);
+	//auto perspect = ray->AddComponent<Rotate3D_Effect>(rayInfo, 0.f, rayBitmap.Get()->GetSize().width / 2.f, rayBitmap.Get()->GetSize().height / 2.f, 0.f, 0.f, 0.2f, rayBitmap.Get());
+	//auto perspect2 = ray->AddComponent<Rotate3D_Effect>(rayInfo, 0.f, rayBitmap.Get()->GetSize().width / 2.f, rayBitmap.Get()->GetSize().height / 2.f, 0.f, 0.f, -0.2f, rayBitmap.Get());
+	//auto composite = ray->AddComponent<Composite_Effect>(rayInfo, perspect->GetEffect(), perspect2->GetEffect(), D2D1_COMPOSITE_MODE_SOURCE_OVER);
+	////auto colorRay = ray->AddComponent<Color_Effect>(rayInfo, 255.f / 256.f, 192.f / 256.f, 203.f / 256.f, 1.f, composite->GetEffect());
+	////auto explodeRay = ray->AddComponent<Explode_Effect>(rayInfo, ray->GetTransform(), 3.f, 3.f, 0.5f);
 
-	m_gameObjects.emplace("4Dust", std::move(ray));
+	//m_gameObjects.emplace("4Dust", std::move(ray));
 
-	auto YrayBitmap = ResourceManager::Get().GetTexture("treasureRay");
-	auto Yray = std::make_unique<Object>();
-	auto YrayInfo = Yray->GetRenderInfo();
-	YrayInfo->SetBitmap(YrayBitmap.Get());
-	Yray->GetTransform().SetPosition({ 500.f, 200.f });
-	Yray->GetTransform().SetPivotPreset(PivotPreset::Center, { YrayBitmap.Get()->GetSize().width, YrayBitmap.Get()->GetSize().height });
-	auto Yblink = Yray->AddComponent<Blinking_Effect>(YrayInfo, 0.95f, 1.f);
-	auto Yperspect = Yray->AddComponent<Rotate3D_Effect>(YrayInfo, 0.f, YrayBitmap.Get()->GetSize().width / 2.f, YrayBitmap.Get()->GetSize().height / 2.f, 0.f, 0.f, 0.15f, YrayBitmap.Get());
-	auto Yperspect2 = Yray->AddComponent<Rotate3D_Effect>(YrayInfo, 0.f, YrayBitmap.Get()->GetSize().width / 2.f, YrayBitmap.Get()->GetSize().height / 2.f, 0.f, 0.f, -0.15f, YrayBitmap.Get());
-	auto Ycomposite = Yray->AddComponent<Composite_Effect>(YrayInfo, Yperspect->GetEffect(), Yperspect2->GetEffect(), D2D1_COMPOSITE_MODE_SOURCE_OVER);
-	m_gameObjects.emplace("5Dust", std::move(Yray));
+	//auto YrayBitmap = ResourceManager::Get().GetTexture("treasureRay");
+	//auto Yray = std::make_unique<Object>();
+	//auto YrayInfo = Yray->GetRenderInfo();
+	//YrayInfo->SetBitmap(YrayBitmap.Get());
+	//Yray->GetTransform().SetPosition({ 500.f, 200.f });
+	//Yray->GetTransform().SetPivotPreset(PivotPreset::Center, { YrayBitmap.Get()->GetSize().width, YrayBitmap.Get()->GetSize().height });
+	//auto Yblink = Yray->AddComponent<Blinking_Effect>(YrayInfo, 0.95f, 1.f);
+	//auto Yperspect = Yray->AddComponent<Rotate3D_Effect>(YrayInfo, 0.f, YrayBitmap.Get()->GetSize().width / 2.f, YrayBitmap.Get()->GetSize().height / 2.f, 0.f, 0.f, 0.15f, YrayBitmap.Get());
+	//auto Yperspect2 = Yray->AddComponent<Rotate3D_Effect>(YrayInfo, 0.f, YrayBitmap.Get()->GetSize().width / 2.f, YrayBitmap.Get()->GetSize().height / 2.f, 0.f, 0.f, -0.15f, YrayBitmap.Get());
+	//auto Ycomposite = Yray->AddComponent<Composite_Effect>(YrayInfo, Yperspect->GetEffect(), Yperspect2->GetEffect(), D2D1_COMPOSITE_MODE_SOURCE_OVER);
+	//m_gameObjects.emplace("5Dust", std::move(Yray));
 
 	//auto runeBitmap = ResourceManager::Get().GetTexture("runeword05");
 	//auto glowBitmap = ResourceManager::Get().GetTexture("basicglow");

--- a/Sinclair/Sinclair/Scene_Title.cpp
+++ b/Sinclair/Sinclair/Scene_Title.cpp
@@ -9,6 +9,8 @@
 #include "UIManager.h"
 #include "SliderHandleComponent.h"
 #include "GameManager.h"
+#include "EffectComponent.h"
+#include "PlayComponent.h"
 
 Scene_Title::Scene_Title(string name)
 {
@@ -69,6 +71,10 @@ void Scene_Title::Clean()
 // 씬 전환 지연 처리를 위해 씬_스탠다드에서 업데이트 일괄 처리.
 void Scene_Title::Update()
 {
+	for (auto& obj : m_gameObjects)
+	{
+		obj.second->Update();
+	}
 	// 씬 전환 지연 처리
 	if (m_isTransitioning && !m_nextScene.empty())
 	{
@@ -86,7 +92,10 @@ void Scene_Title::Update()
 
 void Scene_Title::LogicUpdate(float delta)
 {
-
+	for (auto& obj : m_gameObjects)
+	{
+		obj.second->FixedUpdate(delta);
+	}
 }
 
 
@@ -165,9 +174,40 @@ void Scene_Title::CreateObj()
 	// 3.1.1 사이즈 다르면 
 	bgComp->SetWidth(1920.f); bgComp->SetHeight(1080.f);
 	bgComp->BitmapPush("Background", gameStartBackground);
+	bgComp->SetCurrentBitmap("Background");
 	// 9. 게임 오브젝트들에 집어넣기
 	m_gameObjects.emplace("Background", std::move(Background));
 
+	//////////////////////
+	//////////////////////
+	//////////////////////
+	//	airParticle
+
+	// 1. 이미지 로드
+	auto dustBM = ResourceManager::Get().GetTexture("airParticle");
+	// 2. 오브젝트 생성
+	auto dust1 = std::make_unique<Object>();
+	// 3. 기본 설정
+	auto d1_info = dust1->GetRenderInfo();
+	d1_info->SetBitmap(dustBM.Get());
+	// 4. 컴포넌트 설정
+	auto d1_blur = dust1->AddComponent<GaussianBlur_Effect>(d1_info, 3.f, dustBM.Get());
+	auto d1_updown = dust1->AddComponent<UpDown_Effect>(d1_info, dust1->GetTransform(), 10.f, 0.03f, 0.03f);
+	auto d1_slide = dust1->AddComponent<Slide_Effect>(d1_info, dust1->GetTransform(), 0.07f, 1920.f, 1920.f, true);
+	// 5. 게임 오브젝트 관리 map에 추가
+	m_gameObjects.emplace("b_airDust1", std::move(dust1));
+
+	// 2. 오브젝트 생성
+	auto dust2 = std::make_unique<Object>();
+	// 3. 기본 설정
+	auto d2_info = dust2->GetRenderInfo();
+	d2_info->SetBitmap(dustBM.Get());
+	// 4. 컴포넌트 설정
+	auto d2_blur = dust2->AddComponent<GaussianBlur_Effect>(d2_info, 3.f, dustBM.Get());
+	auto d2_updown = dust2->AddComponent<UpDown_Effect>(d2_info, dust2->GetTransform(), 10.f, 0.03f, 0.03f);
+	auto d2_slide = dust2->AddComponent<Slide_Effect>(d2_info, dust2->GetTransform(), 0.08f, 1920.f, 1920.f, true);
+	// 5. 게임 오브젝트 관리 map에 추가
+	m_gameObjects.emplace("b_airDust2", std::move(dust2));
 
 	//////////////////////
 	//////////////////////
@@ -188,6 +228,7 @@ void Scene_Title::CreateObj()
 	nameComp->SetWidth (gameNameBG->GetSize().width);
 	nameComp->SetHeight(gameNameBG->GetSize().height);
 	nameComp->BitmapPush("gameName", gameNameBG);
+	nameComp->SetCurrentBitmap("gameName");
 	// 9. 게임 오브젝트들에 집어넣기
 	m_gameObjects.emplace("gameName", std::move(gameName));
 
@@ -347,6 +388,7 @@ void Scene_Title::CreateObj()
 		credit01Comp->SetWidth(1059.f);
 		credit01Comp->SetHeight(540.f);
 		credit01Comp->BitmapPush("크레딧_01", credit01Texture);
+		credit01Comp->SetCurrentBitmap("크레딧_01");
 		// 9. 게임 오브젝트들에 집어넣기
 		m_gameObjects.emplace("크레딧_01", std::move(Credit01));
 
@@ -367,6 +409,7 @@ void Scene_Title::CreateObj()
 		credit03Comp->SetWidth(335.f);
 		credit03Comp->SetHeight(283.f);
 		credit03Comp->BitmapPush("크레딧_03", credit03Texture);
+		credit03Comp->SetCurrentBitmap("크레딧_03");
 		// 9. 게임 오브젝트들에 집어넣기
 		m_gameObjects.emplace("크레딧_03", std::move(Credit03));
 
@@ -388,6 +431,7 @@ void Scene_Title::CreateObj()
 		credit06Comp->SetWidth(335.f);
 		credit06Comp->SetHeight(283.f);
 		credit06Comp->BitmapPush("크레딧_06", credit06Texture);
+		credit06Comp->SetCurrentBitmap("크레딧_06");
 		// 9. 게임 오브젝트들에 집어넣기
 		m_gameObjects.emplace("크레딧_06", std::move(Credit06));
 
@@ -453,6 +497,7 @@ void Scene_Title::CreateObj()
 		credit01Comp->SetWidth(1059.f);
 		credit01Comp->SetHeight(540.f);
 		credit01Comp->BitmapPush("크레딧_01", credit01Texture);
+		credit01Comp->SetCurrentBitmap("크레딧_01");
 		// 9. 게임 오브젝트들에 집어넣기
 		m_gameObjects.emplace("크레딧_01", std::move(Credit01));
 


### PR DESCRIPTION
1. play 컴포넌트와 effect 컴포넌트 수정
- 정리 좀 했음

2. Renderinfo 수정
- clear() 함수 추가해서 m_renderinfo 초기화하는 함수 추가
- renderinfo에 z_order 제거

3. title 씬 수정 및 이펙트 추가
- background 컴포넌트의 update() 사용 안한다고 하여 비워버림
- createObj()에서 background 컴포넌트 추가 시, setCurrentBitmap() 함수 호출하여 현재 비트맵 설정해주어야 함.
- 공기 중에 먼지 떠다니는 이펙트 추가

** m_gameobject에 object 삽입 시, 렌더 순서에 맞게 이름을 어떻게 지을 건지 정해야 하지 않나 싶음!! **