### PR TITLE
아이템 사라지는 버그 수정

### DIFF
--- a/Sinclair/Sinclair/Inventory.cpp
+++ b/Sinclair/Sinclair/Inventory.cpp
@@ -644,6 +644,11 @@ bool Inventory::HandleMouseRight(Vec2 mousePos) //사용한 아이템의 포인터를 받아�
         // 아이템 데이터베이스에서 아이템 포인터 가져오기
         Item* itemData = m_itemDatabase.GetItemData(slot->item.id);
 
+        if (slot != nullptr)
+        {
+            CursorManager::Get().SetItemCount(slot->item.count); // 오른쪽 클릭 장착 시에도 해당 값을 set해주기!
+        }
+
         if (Material* material = dynamic_cast<Material*>(itemData))
         {
             std::cout << "해당 아이템은 장비 착용이 불가능 합니다.\n";

--- a/Sinclair/Sinclair/Inventory.cpp
+++ b/Sinclair/Sinclair/Inventory.cpp
@@ -5,6 +5,7 @@
 #include "InvenMem.h"
 #include "Potion.h"
 #include "Wearable.h"
+#include "Material.h"
 //: UI_Object(MWP) //?ì„±?ë¡œ ?ì—­?€ ?¼ë‹¨ ?¤ì •??(Inven ?ê¸° ?ì—­ ë§ì„)
 Inventory::Inventory() :UIWindow(UIWindowType::InventoryWindow, Vec2{ 0,0 }, Vec2{ 1208,825 })  // Vec2{ 1097,766 }) 
 {
@@ -643,7 +644,12 @@ bool Inventory::HandleMouseRight(Vec2 mousePos) //»ç¿ëÇÑ ¾ÆÀÌÅÛÀÇ Æ÷ÀÎÅÍ¸¦ ¹Ş¾Æ¿
         // ¾ÆÀÌÅÛ µ¥ÀÌÅÍº£ÀÌ½º¿¡¼­ ¾ÆÀÌÅÛ Æ÷ÀÎÅÍ °¡Á®¿À±â
         Item* itemData = m_itemDatabase.GetItemData(slot->item.id);
 
-        if (Potion* potion = dynamic_cast<Potion*>(itemData))
+        if (Material* material = dynamic_cast<Material*>(itemData))
+        {
+            std::cout << "ÇØ´ç ¾ÆÀÌÅÛÀº Àåºñ Âø¿ëÀÌ ºÒ°¡´É ÇÕ´Ï´Ù.\n";
+            return false;
+        }
+        else if (Potion* potion = dynamic_cast<Potion*>(itemData))
         {
             // Æ÷¼Ç Ã³¸® ·ÎÁ÷
             int much = potion->GetMuch() - 1;
@@ -654,6 +660,9 @@ bool Inventory::HandleMouseRight(Vec2 mousePos) //»ç¿ëÇÑ ¾ÆÀÌÅÛÀÇ Æ÷ÀÎÅÍ¸¦ ¹Ş¾Æ¿
         {
             // Æ÷¼ÇÀ» ³Ê¹« ¸¹ÀÌ Å¬¸¯ÇÏ¸é ¿À·ù°¡ ÅÍÁü ±×°Å ÇØ°áÇßÀ½ 
             Wearable* wear = dynamic_cast<Wearable*>(itemData);
+
+            //
+            wear->m_data.wearablePart;
             // Âø¿ë ¾ÆÀÌÅÛ Ã³¸® ·ÎÁ÷
             UIManager::Get().OpenWindow(UIWindowType::EquipmentWindow);
             auto equipWindow = dynamic_cast<EquipmentWindow*>(UIManager::Get().GetWindow(UIWindowType::EquipmentWindow));

--- a/Sinclair/Sinclair/SynthesisWin.h
+++ b/Sinclair/Sinclair/SynthesisWin.h
@@ -46,7 +46,7 @@ public:
 
     void UpdatePosition();
     void MemBitmapLoad();
-    void InitializeObj();
+    void ButtonInitialize();
 
     void MemInit();
     void MemRender();


### PR DESCRIPTION
버그 발생 상황:
오른쪽 클릭하여 아이템 장착 후, 드래그하여 인벤으로 되돌릴 때 아이템이 사라지는 버그가 있었음.

해결:
확인 결과, 인벤에서 우클릭으로 아이템 이동시킬 때, CursorManager의 m_draggedItem_Count 값을 set해주지 않고있어서 Inventory::HandleMouseUp() 함수에서 CursorManager의 GetItemCount() 호출 값이 1이 아닌 0이었음. 그리하여 Inventory::HandleMouseRight() 함수에서 CursorManager의 SetItemCount()를 호출하여 버그를 수정하였음.